### PR TITLE
In config environments production rb folder I set config assets compi…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
…le to true, so the pictures would load correctly when deployed to heroku, as the default setting is false and raises the error message about the asset's not being present in the asset pipeline